### PR TITLE
Add POST_TIME env for daily post schedule

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,10 +30,20 @@ HIDDEN_GEMS_CHANNEL_ID=your_channel_id_here
 # Post once immediately when the process starts (smoke tests only)
 POST_ON_START=false
 
-# Cron + timezone for the daily job
-CRON_SCHEDULE=0 9 * * *
+# When to post (timezone-aware). Pick ONE approach:
+#
+# 1) Simple daily time (24-hour HH:MM) — easiest
+POST_TIME=09:00
+#
+# 2) Or hour + minute separately (used if POST_TIME is unset)
+# POST_HOUR=9
+# POST_MINUTE=0
+#
+# 3) Or a full cron expression (overrides POST_TIME / POST_HOUR if set)
+# CRON_SCHEDULE=0 9 * * *
+#
+# Timezone for the schedule (IANA name). TIMEZONE is accepted as an alias.
 TZ=Australia/Melbourne
-# TIMEZONE is accepted as an alias for TZ
 
 # TMDb request shaping
 TMDB_LANGUAGE=en-AU

--- a/README.md
+++ b/README.md
@@ -98,8 +98,10 @@ All settings live in `.env`. Start from [.env.example](.env.example).
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `POST_ON_START` | `false` | Post immediately on boot (testing) |
-| `CRON_SCHEDULE` | `0 9 * * *` | Daily schedule |
-| `TZ` | `Australia/Melbourne` | IANA timezone (`TIMEZONE` also accepted) |
+| `POST_TIME` | `09:00` | Daily post time (`HH:MM`, 24-hour) in `TZ` |
+| `POST_HOUR` / `POST_MINUTE` | — | Alternative to `POST_TIME` if that is unset |
+| `CRON_SCHEDULE` | — | Full cron expression; **overrides** `POST_TIME` / `POST_HOUR` when set |
+| `TZ` | `Australia/Melbourne` | IANA timezone for the schedule (`TIMEZONE` also accepted) |
 | `TMDB_LANGUAGE` | `en-AU` | TMDb language |
 | `TMDB_PAGES` | `4` | Pages fetched per source |
 | `HISTORY_TTL_DAYS` | `90` | Cooldown before a title can be suggested again |
@@ -107,6 +109,24 @@ All settings live in `.env`. Start from [.env.example](.env.example).
 | `SEERR_FAIL_CLOSED` | `true` | Skip titles when Seerr lookup fails |
 
 `WATCH_REGION` accepts country codes or friendly names; the bot normalizes common values for TMDb.
+
+### Setting the post time
+
+Posts run once per day in your chosen timezone. Easiest:
+
+```env
+POST_TIME=18:30
+TZ=America/New_York
+```
+
+Or use a cron expression (overrides `POST_TIME`):
+
+```env
+CRON_SCHEDULE=30 18 * * *
+TZ=America/New_York
+```
+
+After changing schedule env vars, recreate the container: `docker compose up -d --build`. Check logs for `Scheduled discovery: every day at …`.
 
 ## Discord setup
 
@@ -148,7 +168,7 @@ Details: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ## Usage
 
-Once running, the bot posts on `CRON_SCHEDULE` in `TZ`. For a smoke test, set in `.env`:
+Once running, the bot posts daily at `POST_TIME` (or `CRON_SCHEDULE`) in `TZ`. For a smoke test, set in `.env`:
 
 ```env
 POST_ON_START=true
@@ -204,7 +224,7 @@ docker compose up -d --build
 | Request buttons fail | Seerr username/password and permissions |
 | Library titles still appear | Seerr login; `SEERR_FAIL_CLOSED`; see architecture status table |
 | Same titles return too soon | `data/suggested.json` and `HISTORY_TTL_DAYS` |
-| Schedule at the wrong time | `CRON_SCHEDULE` and `TZ` |
+| Schedule at the wrong time | `POST_TIME` / `CRON_SCHEDULE` and `TZ`; recreate container after `.env` edits |
 | Container restarts / build fails | `docker logs -f discoverr`; Docker build output; valid `.env` |
 
 ## Brand

--- a/SETUP.md
+++ b/SETUP.md
@@ -95,13 +95,31 @@ Edit `.env` before starting. Full template: [.env.example](.env.example).
 | `STREAMING_SERVICES` | Comma-separated streaming services to feature |
 | `*_CHANNEL_ID` | One Discord channel ID per category you use |
 
-### Scheduling and discovery tuning
+### When to post
+
+Set a daily time in your timezone (recommended):
+
+```env
+POST_TIME=09:00
+TZ=Australia/Melbourne
+```
+
+Examples: `POST_TIME=07:30` with `TZ=Europe/London`, or `POST_TIME=18:00` with `TZ=America/New_York`.
+
+Alternatives:
+
+| Variable | Purpose |
+|----------|---------|
+| `POST_HOUR` / `POST_MINUTE` | Same as `POST_TIME`, if `POST_TIME` is unset (`POST_MINUTE` defaults to `0`) |
+| `CRON_SCHEDULE` | Full cron (e.g. `0 9 * * *`). **Overrides** `POST_TIME` / `POST_HOUR` when set |
+
+Default if nothing is set: **09:00** daily. After changing these, recreate: `docker compose up -d --build`. Logs should show `Scheduled discovery: every day at …`.
+
+### Other tuning
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `POST_ON_START` | `false` | `true` only while testing |
-| `CRON_SCHEDULE` | `0 9 * * *` | Cron expression |
-| `TZ` | `Australia/Melbourne` | IANA timezone (`TIMEZONE` alias OK) |
 | `TMDB_LANGUAGE` | `en-AU` | TMDb language param |
 | `TMDB_PAGES` | `4` | Pages fetched per source |
 | `HISTORY_TTL_DAYS` | `90` | Days before a suggested title can appear again |
@@ -192,7 +210,7 @@ docker compose up -d --build
 | Request button fails | Seerr username/password and permissions; cookie login uses `email` field |
 | Library titles still appear | Seerr login works; numeric status handling; `SEERR_FAIL_CLOSED` |
 | Same titles return too soon | `data/suggested.json` and `HISTORY_TTL_DAYS` |
-| Schedule wrong time | `CRON_SCHEDULE` and `TZ` |
+| Schedule wrong time | `POST_TIME` / `CRON_SCHEDULE` and `TZ`; recreate after `.env` edits; check log line `Scheduled discovery` |
 | Image build fails | Docker can pull `node:22-alpine`; disk space; valid `package-lock.json` |
 | Streaming category silent | Provider names match TMDb for `WATCH_REGION` |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,7 +28,8 @@ Cron / POST_ON_START
 
 | Path | Responsibility |
 |------|----------------|
-| [`src/index.ts`](../src/index.ts) | Discord client login, cron schedule, `POST_ON_START` |
+| [`src/index.ts`](../src/index.ts) | Discord client login, cron schedule (`POST_TIME` / `CRON_SCHEDULE`), `POST_ON_START` |
+| [`src/lib/schedule.ts`](../src/lib/schedule.ts) | Resolve post time env → cron expression |
 | [`src/config.ts`](../src/config.ts) | Typed environment loading and defaults |
 | [`src/tmdb/client.ts`](../src/tmdb/client.ts) | TMDb HTTP client, multi-page fetch, genres, providers |
 | [`src/tmdb/sources.ts`](../src/tmdb/sources.ts) | Category-specific candidate builders |

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+import { resolveCronSchedule } from "./lib/schedule";
 import { getWatchRegion } from "./lib/watchRegion";
 import type { AppConfig } from "./types";
 
@@ -62,7 +63,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
     streamingChannelId: optional(env, "STREAMING_CHANNEL_ID", ""),
     hiddenGemsChannelId: optional(env, "HIDDEN_GEMS_CHANNEL_ID", ""),
     postOnStart: optionalBool(env, "POST_ON_START", false),
-    cronSchedule: optional(env, "CRON_SCHEDULE", "0 9 * * *"),
+    cronSchedule: resolveCronSchedule(env),
     timezone: optional(env, "TZ", optional(env, "TIMEZONE", "Australia/Melbourne")),
     tmdbLanguage: optional(env, "TMDB_LANGUAGE", "en-AU"),
     historyTtlDays: optionalInt(env, "HISTORY_TTL_DAYS", 90),

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { loadConfig } from "./config";
 import { registerInteractions } from "./discord/interactions";
 import { SuggestionHistory } from "./discovery/history";
 import { postAll } from "./discovery/postAll";
+import { describeDailyCron } from "./lib/schedule";
 import { SeerrClient } from "./seerr/client";
 import { TmdbClient } from "./tmdb/client";
 
@@ -38,7 +39,11 @@ async function main(): Promise<void> {
       { timezone: config.timezone }
     );
 
-    console.log(`Scheduled discovery: ${config.cronSchedule} (${config.timezone})`);
+    const dailyAt = describeDailyCron(config.cronSchedule);
+    const when = dailyAt
+      ? `every day at ${dailyAt} ${config.timezone}`
+      : `${config.cronSchedule} (${config.timezone})`;
+    console.log(`Scheduled discovery: ${when} [cron: ${config.cronSchedule}]`);
 
     if (config.postOnStart) {
       try {

--- a/src/lib/schedule.ts
+++ b/src/lib/schedule.ts
@@ -1,0 +1,62 @@
+/**
+ * Resolve the daily post schedule from env.
+ *
+ * Precedence:
+ * 1. CRON_SCHEDULE (full cron expression)
+ * 2. POST_TIME (HH:MM, 24-hour) → daily at that time
+ * 3. POST_HOUR (+ optional POST_MINUTE) → daily at that time
+ * 4. Default 09:00 → `0 9 * * *`
+ */
+export function resolveCronSchedule(env: NodeJS.ProcessEnv = process.env): string {
+  const cron = env.CRON_SCHEDULE?.trim();
+  if (cron) return cron;
+
+  const postTime = env.POST_TIME?.trim();
+  if (postTime) {
+    return cronFromPostTime(postTime);
+  }
+
+  const hourRaw = env.POST_HOUR?.trim();
+  if (hourRaw) {
+    const hour = parseClockPart(hourRaw, "POST_HOUR", 0, 23);
+    const minuteRaw = env.POST_MINUTE?.trim() || "0";
+    const minute = parseClockPart(minuteRaw, "POST_MINUTE", 0, 59);
+    return `${minute} ${hour} * * *`;
+  }
+
+  return "0 9 * * *";
+}
+
+export function cronFromPostTime(value: string): string {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(value.trim());
+  if (!match) {
+    throw new Error(
+      `Invalid POST_TIME "${value}". Use 24-hour HH:MM, for example 09:00 or 18:30.`
+    );
+  }
+
+  const hour = parseClockPart(match[1], "POST_TIME hour", 0, 23);
+  const minute = parseClockPart(match[2], "POST_TIME minute", 0, 59);
+  return `${minute} ${hour} * * *`;
+}
+
+function parseClockPart(raw: string, label: string, min: number, max: number): number {
+  if (!/^\d{1,2}$/.test(raw)) {
+    throw new Error(`Invalid ${label}: "${raw}" (expected an integer)`);
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new Error(`Invalid ${label}: ${raw} (expected ${min}-${max})`);
+  }
+  return value;
+}
+
+/** Human-readable summary for logs/docs, e.g. "09:00". */
+export function describeDailyCron(cron: string): string | null {
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length !== 5) return null;
+  const [minute, hour, dom, month, dow] = parts;
+  if (dom !== "*" || month !== "*" || dow !== "*") return null;
+  if (!/^\d{1,2}$/.test(minute) || !/^\d{1,2}$/.test(hour)) return null;
+  return `${hour.padStart(2, "0")}:${minute.padStart(2, "0")}`;
+}

--- a/test/schedule.test.ts
+++ b/test/schedule.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  cronFromPostTime,
+  describeDailyCron,
+  resolveCronSchedule
+} from "../src/lib/schedule";
+
+describe("cronFromPostTime", () => {
+  it("builds a daily cron from HH:MM", () => {
+    assert.equal(cronFromPostTime("09:00"), "0 9 * * *");
+    assert.equal(cronFromPostTime("18:30"), "30 18 * * *");
+    assert.equal(cronFromPostTime("0:05"), "5 0 * * *");
+  });
+
+  it("rejects invalid values", () => {
+    assert.throws(() => cronFromPostTime("25:00"));
+    assert.throws(() => cronFromPostTime("9"));
+    assert.throws(() => cronFromPostTime("nine"));
+  });
+});
+
+describe("resolveCronSchedule", () => {
+  it("prefers CRON_SCHEDULE when set", () => {
+    assert.equal(
+      resolveCronSchedule({ CRON_SCHEDULE: "15 20 * * 1-5", POST_TIME: "09:00" }),
+      "15 20 * * 1-5"
+    );
+  });
+
+  it("uses POST_TIME when cron is unset", () => {
+    assert.equal(resolveCronSchedule({ POST_TIME: "14:45" }), "45 14 * * *");
+  });
+
+  it("uses POST_HOUR and POST_MINUTE when cron and POST_TIME are unset", () => {
+    assert.equal(resolveCronSchedule({ POST_HOUR: "7", POST_MINUTE: "15" }), "15 7 * * *");
+    assert.equal(resolveCronSchedule({ POST_HOUR: "7" }), "0 7 * * *");
+  });
+
+  it("defaults to 09:00 daily", () => {
+    assert.equal(resolveCronSchedule({}), "0 9 * * *");
+  });
+});
+
+describe("describeDailyCron", () => {
+  it("summarises simple daily crons", () => {
+    assert.equal(describeDailyCron("0 9 * * *"), "09:00");
+    assert.equal(describeDailyCron("30 18 * * *"), "18:30");
+  });
+
+  it("returns null for non-daily expressions", () => {
+    assert.equal(describeDailyCron("0 9 * * 1"), null);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `POST_TIME=HH:MM` (and `POST_HOUR` / `POST_MINUTE`) so operators can set when recommendations post without writing cron.
- Keep `CRON_SCHEDULE` as an override for advanced schedules.
- Document in README, SETUP, `.env.example`, and architecture notes.
- Unit tests for schedule resolution.

## Test plan
- [x] `npm test` / `npm run typecheck`
- [ ] Set `POST_TIME` + `TZ` on NAS, recreate container, confirm log `Scheduled discovery: every day at …`


Made with [Cursor](https://cursor.com)